### PR TITLE
Add integration tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
+<h2>Change Log</h2>
+<div id="change-log">
+  <h4>Added</h4>
+  <ul id="added">
+    <!-- <li>Feature making everything better</li> -->
+  </ul> 
+  <h4>Fixed</h4>  
+  <ul id="fixed">
+    <!-- <li>Behavior that was incorrect</li> -->
+  </ul>
+  <h4>Changed</h4>
+  <ul id="changed">
+    <!-- <li>Something into something new</li> -->
+  </ul>  
+  <h4>Removed</h4>
+  <ul id="removed">
+    <!-- <li>Something</li> -->
+  </ul>
+  <h4>Deprecated</h4>
+  <ul id="deprecated">
+    <!-- <li>Something is from now deprecated</li> -->
+  </ul>  
+  <h4>Security</h4> 
+  <ul id="security">
+    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
+  </ul>     
+</div>
+<hr/>
+
+<h2>Description</h2>
+
+<!-- Please provide a shore description of changes in this section, feel free to use markdown syntax -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+    - package-ecosystem: "composer"
+      directory: "/"
+      schedule:
+          interval: "daily"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,80 @@
+name: Tests
+
+on:
+    pull_request:
+    push:
+        branches: [1.x]
+    schedule:
+        - cron: '* 8 * * *'
+
+jobs:
+    tests:
+        name: Tests
+        runs-on: ${{ matrix.operating-system }}
+
+        strategy:
+            matrix:
+                dependencies:
+                    - "locked"
+                    - "lowest"
+                    - "highest"
+                php-version:
+                    - "7.4"
+                operating-system:
+                    - "ubuntu-latest"
+                    - "windows-latest"
+
+        services:
+            postgres:
+                image: postgres:11.2
+                env:
+                    POSTGRES_USER: postgres
+                    POSTGRES_PASSWORD: postgres
+                    POSTGRES_DB: postgres
+                ports:
+                    - 5432/tcp
+                options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+
+            - name: Install PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  coverage: pcov
+                  tools: composer:v2
+                  php-version: "${{ matrix.php-version }}"
+                  ini-values: memory_limit=-1
+
+            - name: Get Composer Cache Directory
+              id: composer-cache
+              run: |
+                  echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+            - name: Cache Composer dependencies
+              uses: actions/cache@v2
+              with:
+                  path: |
+                      ${{ steps.composer-cache.outputs.dir }}
+                  key: "php-${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-${{ hashFiles('**/composer.lock') }}"
+                  restore-keys: |
+                      php-${{ matrix.php-version }}-${{ matrix.dependencies }}-composer-
+
+            - name: Install lowest dependencies
+              if: ${{ matrix.dependencies == 'lowest' }}
+              run: "composer update --prefer-lowest --no-interaction --no-progress --no-suggest"
+
+            - name: Install highest dependencies
+              if: ${{ matrix.dependencies == 'highest' }}
+              run: "composer update --no-interaction --no-progress --no-suggest"
+
+            - name: Install locked dependencies
+              if: ${{ matrix.dependencies == 'locked' }}
+              run: "composer install --no-interaction --no-progress --no-suggest"
+
+            - name: Run tests
+              run: composer test
+              env:
+                  DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:${{ job.services.postgres.ports[5432] }}/postgres?serverVersion=11&charset=utf8
+              timeout-minutes: 2

--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,13 @@
             ]
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Flow\\": [
+                "tests/Flow"
+            ]
+        }
+    },
     "scripts": {
         "build": [
             "@static:analyze",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "987bb864f60e8580d8c03a9894df213b",
+    "content-hash": "321d6c69d4c53c7702eda2645a0f284e",
     "packages": [
         {
             "name": "doctrine/cache",
@@ -108,16 +108,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "2.12.0",
+            "version": "2.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "c6d37b4c42aaa3c3ee175f05eca68056f4185646"
+                "reference": "adce7a954a1c2f14f85e94aed90c8489af204086"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/c6d37b4c42aaa3c3ee175f05eca68056f4185646",
-                "reference": "c6d37b4c42aaa3c3ee175f05eca68056f4185646",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/adce7a954a1c2f14f85e94aed90c8489af204086",
+                "reference": "adce7a954a1c2f14f85e94aed90c8489af204086",
                 "shasum": ""
             },
             "require": {
@@ -199,7 +199,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/2.12.0"
+                "source": "https://github.com/doctrine/dbal/tree/2.12.1"
             },
             "funding": [
                 {
@@ -215,7 +215,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-22T17:26:24+00:00"
+            "time": "2020-11-14T20:26:58+00:00"
         },
         {
             "name": "doctrine/event-manager",
@@ -315,36 +315,31 @@
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea"
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f350df0268e904597e3bd9c4685c53e0e333feea",
-                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/d56bf6102915de5702778fe20f2de3b2fe570b5b",
+                "reference": "d56bf6102915de5702778fe20f2de3b2fe570b5b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^6.0",
+                "doctrine/coding-standard": "^8.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^0.13",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-shim": "^0.11",
-                "phpunit/phpunit": "^7.0"
+                "phpbench/phpbench": "^0.13 || 1.0.0-alpha2",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.2.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
@@ -358,7 +353,7 @@
                 {
                     "name": "Marco Pivetta",
                     "email": "ocramius@gmail.com",
-                    "homepage": "http://ocramius.github.com/"
+                    "homepage": "https://ocramius.github.io/"
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
@@ -369,7 +364,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.3.x"
+                "source": "https://github.com/doctrine/instantiator/tree/1.4.0"
             },
             "funding": [
                 {
@@ -385,20 +380,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-29T17:27:14+00:00"
+            "time": "2020-11-10T18:47:58+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.10.1",
+            "version": "1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5"
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
-                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/776f831124e9c62e1a2c601ecc52e776d8bb7220",
+                "reference": "776f831124e9c62e1a2c601ecc52e776d8bb7220",
                 "shasum": ""
             },
             "require": {
@@ -435,7 +430,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.x"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.10.2"
             },
             "funding": [
                 {
@@ -443,20 +438,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-29T13:22:24+00:00"
+            "time": "2020-11-13T09:40:50+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.10.2",
+            "version": "v4.10.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "658f1be311a230e0907f5dfe0213742aff0596de"
+                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/658f1be311a230e0907f5dfe0213742aff0596de",
-                "reference": "658f1be311a230e0907f5dfe0213742aff0596de",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/c6d052fc58cb876152f89f532b95a8d7907e7f0e",
+                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e",
                 "shasum": ""
             },
             "require": {
@@ -497,9 +492,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.10.4"
             },
-            "time": "2020-09-26T10:30:38+00:00"
+            "time": "2020-12-20T10:01:03+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -563,16 +558,16 @@
         },
         {
             "name": "phar-io/version",
-            "version": "3.0.2",
+            "version": "3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "c6bb6825def89e0a32220f88337f8ceaf1975fa0"
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/c6bb6825def89e0a32220f88337f8ceaf1975fa0",
-                "reference": "c6bb6825def89e0a32220f88337f8ceaf1975fa0",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/bae7c545bef187884426f042434e561ab1ddb182",
+                "reference": "bae7c545bef187884426f042434e561ab1ddb182",
                 "shasum": ""
             },
             "require": {
@@ -608,9 +603,9 @@
             "description": "Library for handling version information and constraints",
             "support": {
                 "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/master"
+                "source": "https://github.com/phar-io/version/tree/3.1.0"
             },
-            "time": "2020-06-27T14:39:04+00:00"
+            "time": "2021-02-23T14:00:09+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -772,16 +767,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.1",
+            "version": "1.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d"
+                "reference": "245710e971a030f42e08f4912863805570f23d39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/8ce87516be71aae9b956f81906aaf0338e0d8a2d",
-                "reference": "8ce87516be71aae9b956f81906aaf0338e0d8a2d",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
+                "reference": "245710e971a030f42e08f4912863805570f23d39",
                 "shasum": ""
             },
             "require": {
@@ -793,7 +788,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^6.0",
-                "phpunit/phpunit": "^8.0 || ^9.0 <9.3"
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
@@ -833,22 +828,22 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.12.1"
+                "source": "https://github.com/phpspec/prophecy/tree/1.12.2"
             },
-            "time": "2020-09-29T09:10:42+00:00"
+            "time": "2020-12-19T10:15:11+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.3",
+            "version": "9.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "6b20e2055f7c29b56cb3870b3de7cc463d7add41"
+                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6b20e2055f7c29b56cb3870b3de7cc463d7add41",
-                "reference": "6b20e2055f7c29b56cb3870b3de7cc463d7add41",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f3e026641cc91909d421802dd3ac7827ebfd97e1",
+                "reference": "f3e026641cc91909d421802dd3ac7827ebfd97e1",
                 "shasum": ""
             },
             "require": {
@@ -862,7 +857,7 @@
                 "sebastian/code-unit-reverse-lookup": "^2.0.2",
                 "sebastian/complexity": "^2.0",
                 "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0",
+                "sebastian/lines-of-code": "^1.0.3",
                 "sebastian/version": "^3.0.1",
                 "theseer/tokenizer": "^1.2.0"
             },
@@ -904,7 +899,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.3"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.5"
             },
             "funding": [
                 {
@@ -912,7 +907,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-30T10:46:41+00:00"
+            "time": "2020-11-28T06:44:49+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1157,16 +1152,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.4.2",
+            "version": "9.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3866b2eeeed21b1b099c4bc0b7a1690ac6fd5baa"
+                "reference": "f661659747f2f87f9e72095bb207bceb0f151cb4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3866b2eeeed21b1b099c4bc0b7a1690ac6fd5baa",
-                "reference": "3866b2eeeed21b1b099c4bc0b7a1690ac6fd5baa",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f661659747f2f87f9e72095bb207bceb0f151cb4",
+                "reference": "f661659747f2f87f9e72095bb207bceb0f151cb4",
                 "shasum": ""
             },
             "require": {
@@ -1182,7 +1177,7 @@
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2",
+                "phpunit/php-code-coverage": "^9.2.3",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -1213,7 +1208,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "9.4-dev"
+                    "dev-master": "9.5-dev"
                 }
             },
             "autoload": {
@@ -1244,7 +1239,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.4.2"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.2"
             },
             "funding": [
                 {
@@ -1256,7 +1251,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-19T09:23:29+00:00"
+            "time": "2021-02-02T14:45:58+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -1828,16 +1823,16 @@
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "acf76492a65401babcf5283296fa510782783a7a"
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/acf76492a65401babcf5283296fa510782783a7a",
-                "reference": "acf76492a65401babcf5283296fa510782783a7a",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
                 "shasum": ""
             },
             "require": {
@@ -1873,7 +1868,7 @@
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.2"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
             },
             "funding": [
                 {
@@ -1881,7 +1876,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T17:03:56+00:00"
+            "time": "2020-11-28T06:42:11+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -2224,16 +2219,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.20.0",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
+                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
                 "shasum": ""
             },
             "require": {
@@ -2245,7 +2240,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.22-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2283,7 +2278,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.20.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -2299,7 +2294,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "time": "2021-01-07T16:49:33+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2353,30 +2348,35 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.9.1",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "php": "^7.2 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<3.9.1"
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+                "phpunit/phpunit": "^8.5.13"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -2399,10 +2399,10 @@
                 "validate"
             ],
             "support": {
-                "issues": "https://github.com/webmozart/assert/issues",
-                "source": "https://github.com/webmozart/assert/tree/master"
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.10.0"
             },
-            "time": "2020-07-08T17:02:28+00:00"
+            "time": "2021-03-09T10:59:23+00:00"
         }
     ],
     "aliases": [],
@@ -2410,9 +2410,7 @@
     "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": {
-        "php": ">=7.4.2"
-    },
+    "platform": [],
     "platform-dev": [],
     "plugin-api-version": "2.0.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+    postgres:
+        image: postgres:11.3-alpine
+        container_name: flow-test-db
+        ports:
+            - 5432:5432
+        environment:
+            - POSTGRES_USER=postgres
+            - POSTGRES_PASSWORD=postgres
+            - POSTGRES_DB=postgres

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         cacheResultFile="var/phpunit/.result.cache"
+>
+    <php>
+        <env name="DATABASE_URL" value="postgresql://postgres:postgres@127.0.0.1:5432/postgres?serverVersion=11%26charset=utf8" />
+    </php>
+
+    <logging/>
+    <testsuites>
+        <testsuite name="integration">
+            <directory suffix="">tests/Flow/Doctrine/Tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Flow/Doctrine/Keys.php
+++ b/src/Flow/Doctrine/Keys.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Flow\Doctrine\Dbal;
+namespace Flow\Doctrine;
 
 final class Keys
 {

--- a/src/Flow/Doctrine/PostgreSQL/BulkInsert.php
+++ b/src/Flow/Doctrine/PostgreSQL/BulkInsert.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Flow\Doctrine\Dbal\PostgreSQL;
+namespace Flow\Doctrine\PostgreSQL;
 
 use Doctrine\DBAL\Connection;
-use Flow\Doctrine\Dbal\PostgreSQL\BulkInsert\BulkData;
+use Flow\Doctrine\PostgreSQL\BulkInsert\BulkData;
 
 final class BulkInsert
 {

--- a/src/Flow/Doctrine/PostgreSQL/BulkInsert/BulkData.php
+++ b/src/Flow/Doctrine/PostgreSQL/BulkInsert/BulkData.php
@@ -2,19 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Flow\Doctrine\Dbal\PostgreSQL\PartialBulkInsert;
+namespace Flow\Doctrine\PostgreSQL\BulkInsert;
 
-use Flow\Doctrine\Dbal\Keys;
+use Flow\Doctrine\Keys;
 
-final class PartialBulkData
+final class BulkData
 {
     private Keys $keys;
 
     private array $rows;
 
-    private Keys $onConflictUpdateKeys;
-
-    public function __construct(Keys $onConflictUpdateKeys, array $data)
+    public function __construct(array $data)
     {
         $this->keys = new Keys(...\array_keys(\reset($data)));
         $this->rows = \array_map(
@@ -24,7 +22,6 @@ final class PartialBulkData
             \range(0, \count($data) - 1),
             $data
         );
-        $this->onConflictUpdateKeys = $onConflictUpdateKeys;
     }
 
     public function placeholders() : string
@@ -52,6 +49,6 @@ final class PartialBulkData
 
     public function onConflictUpdate() : string
     {
-        return $this->onConflictUpdateKeys->asSQLSetUsingExcludedTable();
+        return $this->keys->asSQLSetUsingExcludedTable();
     }
 }

--- a/src/Flow/Doctrine/PostgreSQL/PartialBulkInsert.php
+++ b/src/Flow/Doctrine/PostgreSQL/PartialBulkInsert.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace Flow\Doctrine\Dbal\PostgreSQL;
+namespace Flow\Doctrine\PostgreSQL;
 
 use Doctrine\DBAL\Connection;
-use Flow\Doctrine\Dbal\PostgreSQL\PartialBulkInsert\PartialBulkData;
+use Flow\Doctrine\PostgreSQL\PartialBulkInsert\PartialBulkData;
 
 final class PartialBulkInsert
 {

--- a/src/Flow/Doctrine/PostgreSQL/PartialBulkInsert/PartialBulkData.php
+++ b/src/Flow/Doctrine/PostgreSQL/PartialBulkInsert/PartialBulkData.php
@@ -2,17 +2,19 @@
 
 declare(strict_types=1);
 
-namespace Flow\Doctrine\Dbal\PostgreSQL\BulkInsert;
+namespace Flow\Doctrine\PostgreSQL\PartialBulkInsert;
 
-use Flow\Doctrine\Dbal\Keys;
+use Flow\Doctrine\Keys;
 
-final class BulkData
+final class PartialBulkData
 {
     private Keys $keys;
 
     private array $rows;
 
-    public function __construct(array $data)
+    private Keys $onConflictUpdateKeys;
+
+    public function __construct(Keys $onConflictUpdateKeys, array $data)
     {
         $this->keys = new Keys(...\array_keys(\reset($data)));
         $this->rows = \array_map(
@@ -22,6 +24,7 @@ final class BulkData
             \range(0, \count($data) - 1),
             $data
         );
+        $this->onConflictUpdateKeys = $onConflictUpdateKeys;
     }
 
     public function placeholders() : string
@@ -49,6 +52,6 @@ final class BulkData
 
     public function onConflictUpdate() : string
     {
-        return $this->keys->asSQLSetUsingExcludedTable();
+        return $this->onConflictUpdateKeys->asSQLSetUsingExcludedTable();
     }
 }

--- a/tests/Flow/Doctrine/Tests/Context/DatabaseContext.php
+++ b/tests/Flow/Doctrine/Tests/Context/DatabaseContext.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Doctrine\Tests\Context;
+
+use Doctrine\DBAL\Connection;
+
+final class DatabaseContext
+{
+    private Connection $connection;
+
+    private InsertQueryCounter $sqlLogger;
+
+    /**
+     * @var string[]
+     */
+    private array $createdTables;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
+        $this->sqlLogger = new InsertQueryCounter();
+        $this->createdTables = [];
+
+        $this->connection->getConfiguration()->setSQLLogger($this->sqlLogger);
+    }
+
+    public function connection() : Connection
+    {
+        return $this->connection;
+    }
+
+    public function createTestTable(string $tableName) : void
+    {
+        $this->connection->executeQuery("CREATE TABLE {$tableName} (id INT NOT NULL, name VARCHAR(255) NOT NULL, description VARCHAR(255) NOT NULL, PRIMARY KEY(id))");
+
+        $this->createdTables[] = $tableName;
+    }
+
+    public function selectAll(string $tableName) : array
+    {
+        return $this->connection->fetchAllAssociative("SELECT * FROM {$tableName} ORDER BY id");
+    }
+
+    public function tableCount(string $tableName) : int
+    {
+        return (int) $this->connection->fetchOne("SELECT COUNT(*) FROM $tableName");
+    }
+
+    public function numberOfExecutedInsertQueries() : int
+    {
+        return $this->sqlLogger->count;
+    }
+
+    public function dropAllTables() : void
+    {
+        foreach ($this->createdTables as $table) {
+            $this->connection->executeQuery("DROP TABLE {$table}");
+        }
+    }
+}

--- a/tests/Flow/Doctrine/Tests/Context/InsertQueryCounter.php
+++ b/tests/Flow/Doctrine/Tests/Context/InsertQueryCounter.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Doctrine\Tests\Context;
+
+use Doctrine\DBAL\Logging\SQLLogger;
+
+final class InsertQueryCounter implements SQLLogger
+{
+    public int $count = 0;
+
+    public function startQuery($sql, ?array $params = null, ?array $types = null)
+    {
+        if (\stripos(trim($sql), 'INSERT') === 0) {
+            $this->count++;
+        }
+    }
+
+    public function stopQuery()
+    {
+    }
+}

--- a/tests/Flow/Doctrine/Tests/Integration/PostgreSQL/BulkInsertTest.php
+++ b/tests/Flow/Doctrine/Tests/Integration/PostgreSQL/BulkInsertTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Doctrine\Tests\Integration\PostgreSQL;
+
+use Flow\Doctrine\PostgreSQL\BulkInsert;
+use Flow\Doctrine\Tests\IntegrationTestCase;
+
+final class BulkInsertTest extends IntegrationTestCase
+{
+    public function test_inserts_multiple_rows_at_once() : void
+    {
+        $this->databaseContext->createTestTable($table = 'flow_doctrine_bulk_test');
+
+        BulkInsert::insert($table)->execute($this->databaseContext->connection(), new BulkInsert\BulkData([
+            ['id' => 1, 'name' => 'Name One', 'description' => 'Description One'],
+            ['id' => 2, 'name' => 'Name Two', 'description' => 'Description Two'],
+            ['id' => 3, 'name' => 'Name Three', 'description' => 'Description Three']
+        ]));
+
+        $this->assertEquals(3, $this->databaseContext->tableCount($table));
+        $this->assertEquals(1, $this->databaseContext->numberOfExecutedInsertQueries());
+    }
+
+    public function test_insert_new_rows_or_updates_already_existed_based_on_primary_key() : void
+    {
+        $this->databaseContext->createTestTable($table = 'flow_doctrine_bulk_test');
+        BulkInsert::insert($table)->execute($this->databaseContext->connection(), new BulkInsert\BulkData([
+            ['id' => 1, 'name' => 'Name One', 'description' => 'Description One'],
+            ['id' => 2, 'name' => 'Name Two', 'description' => 'Description Two'],
+            ['id' => 3, 'name' => 'Name Three', 'description' => 'Description Three']
+        ]));
+
+        BulkInsert::upsertOnConflictOnConstraint($table, 'flow_doctrine_bulk_test_pkey')->execute($this->databaseContext->connection(), new BulkInsert\BulkData([
+            ['id' => 2, 'name' => 'New Name Two', 'description' => 'New Description Two'],
+            ['id' => 3, 'name' => 'New Name Three', 'description' => 'New Description Three'],
+            ['id' => 4, 'name' => 'New Name Four', 'description' => 'New Description Three']
+        ]));
+
+        $this->assertEquals(4, $this->databaseContext->tableCount($table));
+        $this->assertEquals(2, $this->databaseContext->numberOfExecutedInsertQueries());
+        $this->assertEquals(
+            [
+                ['id' => 1, 'name' => 'Name One', 'description' => 'Description One'],
+                ['id' => 2, 'name' => 'New Name Two', 'description' => 'New Description Two'],
+                ['id' => 3, 'name' => 'New Name Three', 'description' => 'New Description Three'],
+                ['id' => 4, 'name' => 'New Name Four', 'description' => 'New Description Three']
+            ],
+            $this->databaseContext->selectAll($table)
+        );
+    }
+
+    public function test_insert_new_rows_or_updates_already_existed_based_on_column() : void
+    {
+        $this->databaseContext->createTestTable($table = 'flow_doctrine_bulk_test');
+        BulkInsert::insert($table)->execute($this->databaseContext->connection(), new BulkInsert\BulkData([
+            ['id' => 1, 'name' => 'Name One', 'description' => 'Description One'],
+            ['id' => 2, 'name' => 'Name Two', 'description' => 'Description Two'],
+            ['id' => 3, 'name' => 'Name Three', 'description' => 'Description Three']
+        ]));
+
+        BulkInsert::upsertOnColumnConflict($table, 'id')->execute($this->databaseContext->connection(), new BulkInsert\BulkData([
+            ['id' => 2, 'name' => 'New Name Two', 'description' => 'New Description Two'],
+            ['id' => 3, 'name' => 'New Name Three', 'description' => 'New Description Three'],
+            ['id' => 4, 'name' => 'New Name Four', 'description' => 'New Description Three']
+        ]));
+
+        $this->assertEquals(4, $this->databaseContext->tableCount($table));
+        $this->assertEquals(2, $this->databaseContext->numberOfExecutedInsertQueries());
+        $this->assertEquals(
+            [
+                ['id' => 1, 'name' => 'Name One', 'description' => 'Description One'],
+                ['id' => 2, 'name' => 'New Name Two', 'description' => 'New Description Two'],
+                ['id' => 3, 'name' => 'New Name Three', 'description' => 'New Description Three'],
+                ['id' => 4, 'name' => 'New Name Four', 'description' => 'New Description Three']
+            ],
+            $this->databaseContext->selectAll($table)
+        );
+    }
+
+    public function test_insert_new_rows_and_skip_already_existed() : void
+    {
+        $this->databaseContext->createTestTable($table = 'flow_doctrine_bulk_test');
+        BulkInsert::insert($table)->execute($this->databaseContext->connection(), new BulkInsert\BulkData([
+            ['id' => 1, 'name' => 'Name One', 'description' => 'Description One'],
+            ['id' => 2, 'name' => 'Name Two', 'description' => 'Description Two'],
+            ['id' => 3, 'name' => 'Name Three', 'description' => 'Description Three']
+        ]));
+
+        BulkInsert::insertOnConflictDoNothing($table)->execute($this->databaseContext->connection(), new BulkInsert\BulkData([
+            ['id' => 2, 'name' => 'New Name Two', 'description' => 'New Description Two'],
+            ['id' => 3, 'name' => 'New Name Three', 'description' => 'New Description Three'],
+            ['id' => 4, 'name' => 'New Name Four', 'description' => 'New Description Three']
+        ]));
+
+        $this->assertEquals(4, $this->databaseContext->tableCount($table));
+        $this->assertEquals(2, $this->databaseContext->numberOfExecutedInsertQueries());
+        $this->assertEquals(
+            [
+                ['id' => 1, 'name' => 'Name One', 'description' => 'Description One'],
+                ['id' => 2, 'name' => 'Name Two', 'description' => 'Description Two'],
+                ['id' => 3, 'name' => 'Name Three', 'description' => 'Description Three'],
+                ['id' => 4, 'name' => 'New Name Four', 'description' => 'New Description Three']
+            ],
+            $this->databaseContext->selectAll($table)
+        );
+    }
+}

--- a/tests/Flow/Doctrine/Tests/IntegrationTestCase.php
+++ b/tests/Flow/Doctrine/Tests/IntegrationTestCase.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Flow\Doctrine\Tests;
+
+use Doctrine\DBAL\DriverManager;
+use Flow\Doctrine\Tests\Context\DatabaseContext;
+use PHPUnit\Framework\TestCase;
+
+abstract class IntegrationTestCase extends TestCase
+{
+    protected DatabaseContext $databaseContext;
+
+    protected function setUp() : void
+    {
+        $this->databaseContext = new DatabaseContext(DriverManager::getConnection(['url' => \getenv('DATABASE_URL')]));
+    }
+
+    protected function tearDown() : void
+    {
+        $this->databaseContext->dropAllTables();
+    }
+}


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <li>Integration tests</li>
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <!-- <li>Something into something new</li> -->
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>
It adds missing integration tests. Some are still missing. This PR only propose how we could test it to start discussion. After the decision I'll cover with tests the rest of classes.

I added `docker-compose` to be able to execute tests locally on dev machine (I'll describe it in the documention). I think that phpunit config and docker-compose should be as `dist` files. Why? Because now there is hardcoded port for postgresql but it may be already in use so we should allow to change it if needed. What do you think?