### PR TITLE
Sort data accroding to keys in BulkData

### DIFF
--- a/src/Flow/Doctrine/Bulk/BulkData.php
+++ b/src/Flow/Doctrine/Bulk/BulkData.php
@@ -33,22 +33,26 @@ final class BulkData
         }
 
         $keys = \array_keys($firstRow);
+        \sort($keys);
 
         foreach ($rows as $row) {
             if (!\is_array($row)) {
                 throw new RuntimeException('Each row must be an array');
             }
 
-            if ($keys !== \array_keys($row)) {
-                throw new RuntimeException('Each row must be have the same keys in the same order');
+            $rowKeys = \array_keys($row);
+            \sort($rowKeys);
+
+            if ($keys !== $rowKeys) {
+                throw new RuntimeException('Each row must be have the same keys');
             }
         }
 
-        $this->columns = new Columns(...$keys);
+        $this->columns = new Columns(...\array_keys($firstRow));
         $this->rows = \array_map( /** @phpstan-ignore-line */
             fn (int $index, array $row) => \array_combine(
                 $this->columns->suffix("_{$index}")->all(),
-                $row,
+                $this->columns->sort($row),
             ),
             \range(0, \count($rows) - 1),
             $rows

--- a/src/Flow/Doctrine/Bulk/Columns.php
+++ b/src/Flow/Doctrine/Bulk/Columns.php
@@ -50,6 +50,24 @@ final class Columns
     }
 
     /**
+     * @psalm-suppress MixedAssignment
+     *
+     * @param mixed[] $data
+     *
+     * @return mixed[]
+     */
+    public function sort(array $data) : array
+    {
+        $sortedData = [];
+
+        foreach ($this->columns as $column) {
+            $sortedData[$column] = $data[$column];
+        }
+
+        return $sortedData;
+    }
+
+    /**
      * @return string[]
      */
     public function all() : array

--- a/tests/Flow/Doctrine/Bulk/Tests/Unit/BulkDataTest.php
+++ b/tests/Flow/Doctrine/Bulk/Tests/Unit/BulkDataTest.php
@@ -41,7 +41,7 @@ final class BulkDataTest extends TestCase
 
     public function test_prevents_creating_bulk_data_for_different_rows() : void
     {
-        $this->expectExceptionMessage('Each row must be have the same keys in the same order');
+        $this->expectExceptionMessage('Each row must be have the same keys');
 
         new BulkData([
             [
@@ -51,10 +51,11 @@ final class BulkDataTest extends TestCase
                 'quantity' => 101,
             ],
             [
-                'title' => 'Title One',
                 'date' => 'today',
-                'quantity' => 101,
+                'title' => 'Title One',
                 'description' => 'Description One',
+                'quantity' => 101,
+                'status' => 'completed',
             ],
         ]);
     }
@@ -92,10 +93,10 @@ final class BulkDataTest extends TestCase
                 'quantity' => 101,
             ],
             [
-                'date' => 'today',
                 'title' => 'Title Two',
-                'description' => 'Description Two',
+                'date' => 'today',
                 'quantity' => 102,
+                'description' => 'Description Two',
             ],
         ]);
 
@@ -124,10 +125,10 @@ final class BulkDataTest extends TestCase
                 'quantity' => 101,
             ],
             [
-                'date' => 'today',
                 'title' => 'Title Two',
-                'description' => 'Description Two',
+                'date' => 'today',
                 'quantity' => 102,
+                'description' => 'Description Two',
             ],
         ]);
 

--- a/tests/Flow/Doctrine/Bulk/Tests/Unit/ColumnsTest.php
+++ b/tests/Flow/Doctrine/Bulk/Tests/Unit/ColumnsTest.php
@@ -52,4 +52,26 @@ final class ColumnsTest extends TestCase
             $columns->concat(',')
         );
     }
+
+    public function test_sorts_given_rows_in_order_of_columns() : void
+    {
+        $columns = new Columns('date', 'title', 'description', 'quantity');
+
+        $sorted = $columns->sort([
+            'quantity' => 101,
+            'title' => 'Title One',
+            'date' => 'today',
+            'description' => 'Description One',
+        ]);
+
+        $this->assertEquals(
+            [
+                'date' => 'today',
+                'title' => 'Title One',
+                'description' => 'Description One',
+                'quantity' => 101,
+            ],
+            $sorted
+        );
+    }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
<li>Sort BulkData according to the keys of first row</li>
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
    <!-- <li>Something</li> -->
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

We can allow a different order of keys in BulkData as long the keys are the same. 
