### PR TITLE
Dont use deprecated getName() method on Doctrine Dbal Platform class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "keywords": ["doctrine", "dbal", "bulk", "insert", "upsert"],
     "require": {
         "php": "^7.4 | ^8.0",
-        "doctrine/dbal": "^2.12 | ^3.0"
+        "doctrine/dbal": "^2.12 | ^3.1.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "sort-packages": true
     },
     "scripts": {
+        "tools:install": "composer install --working-dir=./tools",
         "build": [
             "@static:analyze",
             "@test",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "526f951be5e3d402e1b21acf51a58d27",
+    "content-hash": "d4cd97daaba4f6336b616337ba137462",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",

--- a/composer.lock
+++ b/composer.lock
@@ -536,5 +536,5 @@
         "php": "^7.4 | ^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/infection.json
+++ b/infection.json
@@ -25,6 +25,11 @@
                 "Flow\\Doctrine\\Bulk\\QueryFactory\\DbalQueryFactory"
             ]
         },
+        "Identical": {
+            "ignore": [
+                "Flow\\Doctrine\\Bulk\\QueryFactory\\DbalPlatform"
+            ]
+        },
         "UnwrapArrayFilter": {
             "ignore": [
                 "Flow\\Doctrine\\Bulk\\BulkInsert"

--- a/src/Flow/Doctrine/Bulk/QueryFactory/DbalPlatform.php
+++ b/src/Flow/Doctrine/Bulk/QueryFactory/DbalPlatform.php
@@ -1,0 +1,29 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Doctrine\Bulk\QueryFactory;
+
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+
+final class DbalPlatform
+{
+    private AbstractPlatform $platform;
+
+    public function __construct(AbstractPlatform $platform)
+    {
+        $this->platform = $platform;
+    }
+
+    public function isPostgreSQL() : bool
+    {
+        // DBAL version >= 3.2
+        if (\class_exists(PostgreSQLPlatform::class)) {
+            return $this->platform instanceof PostgreSQLPlatform;
+        }
+
+        /**
+         * @psalm-suppress DeprecatedMethod
+         */
+        return $this->platform->getName() === 'postgresql';
+    }
+}

--- a/src/Flow/Doctrine/Bulk/QueryFactory/DbalQueryFactory.php
+++ b/src/Flow/Doctrine/Bulk/QueryFactory/DbalQueryFactory.php
@@ -12,8 +12,6 @@ use Flow\Doctrine\Bulk\QueryFactory;
 class DbalQueryFactory implements QueryFactory
 {
     /**
-     * @psalm-suppress DeprecatedMethod
-     *
      * @param AbstractPlatform $platform
      * @param string $table
      * @param BulkData $bulkData
@@ -24,7 +22,7 @@ class DbalQueryFactory implements QueryFactory
      */
     public function insert(AbstractPlatform $platform, string $table, BulkData $bulkData) : string
     {
-        if ($platform->getName() === 'postgresql') {
+        if ((new DbalPlatform($platform))->isPostgreSQL()) {
             return \sprintf(
                 'INSERT INTO %s (%s) VALUES %s',
                 $table,
@@ -35,13 +33,11 @@ class DbalQueryFactory implements QueryFactory
 
         throw new RuntimeException(\sprintf(
             'Database platform "%s" is not supported by this factory',
-            $platform->getName()
+            \get_class($platform)
         ));
     }
 
     /**
-     * @psalm-suppress DeprecatedMethod
-     *
      * @param AbstractPlatform $platform
      * @param string $table
      * @param BulkData $bulkData
@@ -52,7 +48,7 @@ class DbalQueryFactory implements QueryFactory
      */
     public function insertOrSkipOnConflict(AbstractPlatform $platform, string $table, BulkData $bulkData) : string
     {
-        if ($platform->getName() === 'postgresql') {
+        if ((new DbalPlatform($platform))->isPostgreSQL()) {
             return \sprintf(
                 'INSERT INTO %s (%s) VALUES %s ON CONFLICT DO NOTHING',
                 $table,
@@ -63,13 +59,11 @@ class DbalQueryFactory implements QueryFactory
 
         throw new RuntimeException(\sprintf(
             'Database platform "%s" is not supported by this factory',
-            $platform->getName()
+            \get_class($platform)
         ));
     }
 
     /**
-     * @psalm-suppress DeprecatedMethod
-     *
      * @param AbstractPlatform $platform
      * @param string $table
      * @param string $constraint
@@ -81,7 +75,7 @@ class DbalQueryFactory implements QueryFactory
      */
     public function insertOrUpdateOnConstraintConflict(AbstractPlatform $platform, string $table, string $constraint, BulkData $bulkData) : string
     {
-        if ($platform->getName() === 'postgresql') {
+        if ((new DbalPlatform($platform))->isPostgreSQL()) {
             return \sprintf(
                 'INSERT INTO %s (%s) VALUES %s ON CONFLICT ON CONSTRAINT %s DO UPDATE SET %s',
                 $table,
@@ -104,13 +98,11 @@ class DbalQueryFactory implements QueryFactory
 
         throw new RuntimeException(\sprintf(
             'Database platform "%s" is not supported by this factory',
-            $platform->getName()
+            \get_class($platform)
         ));
     }
 
     /**
-     * @psalm-suppress DeprecatedMethod
-     *
      * @param AbstractPlatform $platform
      * @param string $table
      * @param array<string> $conflictColumns
@@ -123,7 +115,7 @@ class DbalQueryFactory implements QueryFactory
      */
     public function insertOrUpdateOnConflict(AbstractPlatform $platform, string $table, array $conflictColumns, BulkData $bulkData, array $updateColumns = []) : string
     {
-        if ($platform->getName() === 'postgresql') {
+        if ((new DbalPlatform($platform))->isPostgreSQL()) {
             return \sprintf(
                 'INSERT INTO %s (%s) VALUES %s ON CONFLICT (%s) DO UPDATE SET %s',
                 $table,
@@ -148,7 +140,7 @@ class DbalQueryFactory implements QueryFactory
 
         throw new RuntimeException(\sprintf(
             'Database platform "%s" is not supported by this factory',
-            $platform->getName()
+            \get_class($platform)
         ));
     }
 }

--- a/src/Flow/Doctrine/Bulk/QueryFactory/DbalQueryFactory.php
+++ b/src/Flow/Doctrine/Bulk/QueryFactory/DbalQueryFactory.php
@@ -12,6 +12,8 @@ use Flow\Doctrine\Bulk\QueryFactory;
 class DbalQueryFactory implements QueryFactory
 {
     /**
+     * @psalm-suppress DeprecatedMethod
+     *
      * @param AbstractPlatform $platform
      * @param string $table
      * @param BulkData $bulkData
@@ -38,6 +40,8 @@ class DbalQueryFactory implements QueryFactory
     }
 
     /**
+     * @psalm-suppress DeprecatedMethod
+     *
      * @param AbstractPlatform $platform
      * @param string $table
      * @param BulkData $bulkData
@@ -64,6 +68,8 @@ class DbalQueryFactory implements QueryFactory
     }
 
     /**
+     * @psalm-suppress DeprecatedMethod
+     *
      * @param AbstractPlatform $platform
      * @param string $table
      * @param string $constraint
@@ -103,6 +109,8 @@ class DbalQueryFactory implements QueryFactory
     }
 
     /**
+     * @psalm-suppress DeprecatedMethod
+     *
      * @param AbstractPlatform $platform
      * @param string $table
      * @param array<string> $conflictColumns

--- a/tests/Flow/Doctrine/Bulk/Tests/Unit/DbalPlatformTest.php
+++ b/tests/Flow/Doctrine/Bulk/Tests/Unit/DbalPlatformTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Flow\Doctrine\Bulk\Tests\Unit;
+
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Flow\Doctrine\Bulk\QueryFactory\DbalPlatform;
+use PHPUnit\Framework\TestCase;
+
+final class DbalPlatformTest extends TestCase
+{
+    public function test_is_postgres_sql_for_dbal_3_2() : void
+    {
+        if (!\class_exists(PostgreSQLPlatform::class)) {
+            $this->markTestSkipped('DBAL version < 3.2');
+        }
+
+        $platform = new DbalPlatform(new PostgreSQLPlatform());
+
+        $this->assertTrue($platform->isPostgreSQL());
+    }
+
+    public function test_is_postgres_sql_for_dbal_less_than_3_2() : void
+    {
+        if (\class_exists(PostgreSQLPlatform::class)) {
+            $this->markTestSkipped('DBAL version >= 3.2');
+        }
+
+        $platform = new DbalPlatform(new PostgreSQL94Platform());
+
+        $this->assertTrue($platform->isPostgreSQL());
+    }
+}

--- a/tests/Flow/Doctrine/Bulk/Tests/Unit/DbalPlatformTest.php
+++ b/tests/Flow/Doctrine/Bulk/Tests/Unit/DbalPlatformTest.php
@@ -4,6 +4,7 @@ namespace Flow\Doctrine\Bulk\Tests\Unit;
 
 use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Flow\Doctrine\Bulk\QueryFactory\DbalPlatform;
 use PHPUnit\Framework\TestCase;
 
@@ -29,5 +30,12 @@ final class DbalPlatformTest extends TestCase
         $platform = new DbalPlatform(new PostgreSQL94Platform());
 
         $this->assertTrue($platform->isPostgreSQL());
+    }
+
+    public function test_is_no_postgres_sql() : void
+    {
+        $platform = new DbalPlatform(new SqlitePlatform());
+
+        $this->assertFalse($platform->isPostgreSQL());
     }
 }


### PR DESCRIPTION
<!-- Bellow section will be used to automatically generate changelog, please do not modify HTML code structure -->
<h2>Change Log</h2>
<div id="change-log">
  <h4>Added</h4>
  <ul id="added">
    <!-- <li>Feature making everything better</li> -->
  </ul> 
  <h4>Fixed</h4>  
  <ul id="fixed">
    <!-- <li>Behavior that was incorrect</li> -->
  </ul>
  <h4>Changed</h4>
  <ul id="changed">
    <li>Deprecated errors from PHPStan</li>
	
  </ul>  
  <h4>Removed</h4>
  <ul id="removed">
     <li>Support for Doctrine Dbal 2.x</li> 
  </ul>
  <h4>Deprecated</h4>
  <ul id="deprecated">
    <!-- <li>Something is from now deprecated</li> -->
  </ul>  
  <h4>Security</h4> 
  <ul id="security">
    <!-- <li>Something that was security issue, is not an issue anymore</li> -->
  </ul>     
</div>
<hr/>

<h2>Description</h2>

`AbstractPlatform::getName` is deprecated in Doctrine 3.x. This PR introduces a BC break, because it drops support for Dbal 2.x. Let me know if we should support it both versions: 2.x and 3.x. I'll find a way.

**EDIT**
This class was added in DBAL 3.2 https://github.com/doctrine/dbal/blob/3.2.0/src/Platforms/PostgreSQLPlatform.php, but in the same time https://github.com/doctrine/dbal/blob/3.2.0/src/Platforms/PostgreSQL94Platform.php was mark as deprecated. It's hard to support 3.1.x and 3.2.x with PHPStan - I think the only way is to suppress deprecated warnings on that `PostgreSQL94Platform` class.  Another way us to support Dbal from 3.2.x, which I did in this PR.